### PR TITLE
fix: replace hardcoded absolute path with relative path

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,7 +36,9 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: str)
 
 
 if __name__ == "__main__":
-    file = "/home/juan/Documents/california/UCSC/rte2025/src/inputs/file.pdf"
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    file = os.path.join(script_dir, "inputs", "file.pdf")
     input = "Hi. The employee's name is John Doe. His job title is managing director. His department supervisor is Jane Doe. His phone number is 123456. His email is jdoe@ucsc.edu. The signature is <Mamañema>, and the date is 01/02/2005"
     descriptions = ["Employee's name", "Employee's job title", "Employee's department supervisor", "Employee's phone number", "Employee's email", "Signature", "Date"]
     run_pdf_fill_process(input, descriptions, file)
+    


### PR DESCRIPTION
## Fix hardcoded file path in main.py

Replaced the absolute path with a relative path using `os.path` to make the test case portable across different environments.

**Changes:**
- Use `os.path.dirname` and `os.path.abspath` to determine script location
- Build path relative to script directory instead of hardcoded absolute path

Fixes #11 